### PR TITLE
AMB-985 Add check for https protocol on json schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -17,7 +17,8 @@
                     ],
                     "properties": {
                         "target": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "^https:\/\/.*"
                         }
                     },
                     "additionalProperties": false

--- a/targets/internal-dev/targets.json
+++ b/targets/internal-dev/targets.json
@@ -1,7 +1,7 @@
 {
     "NHSD-ServiceIdentifier": {
       "NHS0001": {
-        "target": "http://internal-dev.api.service.nhs.uk/bars-mock-receiver-proxy"
+        "target": "https://internal-dev.api.service.nhs.uk/bars-mock-receiver-proxy"
       },
       "NHS0001-401": {
         "target": "https://internal-dev.api.service.nhs.uk/bars-mock-receiver-proxy/errors"

--- a/targets/internal-dev/targets.json
+++ b/targets/internal-dev/targets.json
@@ -1,7 +1,7 @@
 {
     "NHSD-ServiceIdentifier": {
       "NHS0001": {
-        "target": "https://internal-dev.api.service.nhs.uk/bars-mock-receiver-proxy"
+        "target": "http://internal-dev.api.service.nhs.uk/bars-mock-receiver-proxy"
       },
       "NHS0001-401": {
         "target": "https://internal-dev.api.service.nhs.uk/bars-mock-receiver-proxy/errors"


### PR DESCRIPTION
Add check for https:// on json schema (All BaRS targets use MTLS so the only valid protocol is https)